### PR TITLE
Update maxxecu_default_can.xml

### DIFF
--- a/RealDash-CAN/XML-files/MaxxECU/maxxecu_default_can.xml
+++ b/RealDash-CAN/XML-files/MaxxECU/maxxecu_default_can.xml
@@ -87,6 +87,21 @@
       <value name="MaxxECU: Spare 2" offset="6" length="2" signed="true"></value>
     </frame>
 
+    <frame id="0x538">
+      <value name="MaxxECU: User Channel 1" offset="0" length="2" conversion="V*0.1"></value>
+      <value name="MaxxECU: User Channel 2" offset="2" length="2" conversion="V*0.1"></value>
+      <value name="MaxxECU: User Channel 3" offset="4" length="2" conversion="V*0.1"></value>
+      <value name="MaxxECU: User Channel 4" offset="6" length="2" conversion="V*0.1"></value>
+    </frame>
+    
+    <frame id="0x540">
+      <value name="MaxxECU: Active Boost Table" offset="0" length="1"></value>
+      <value name="MaxxECU: Active Tune Selector" offset="1" length="1"></value>
+      <value name="MaxxECU: Virtual Fuel Tank" offset="2" length="2" conversion="V*0.1"></value>
+      <value name="MaxxECU: Transmission Temp" units="C" offset="4" length="2" conversion="V*0.1"></value>
+      <value name="MaxxECU: Differential Temp" units="C" offset="6" length="2" conversion="V*0.1"></value>
+    </frame>
+    
   </frames>
 </RealDashCAN>
 


### PR DESCRIPTION
Added 0x538 and 0x540 packet descriptors for MaxxECU, includes User Channels 1-4, tran/diff temp, virtual fuel tank level, Active Boost table and Active Tune Selector.